### PR TITLE
Spelling fix, and updated Discord invite link

### DIFF
--- a/index.html
+++ b/index.html
@@ -91,7 +91,7 @@
           <h5>Join us!</h5>
 
           <p>
-            We mainly talk on IRC and TeamsSpeak. If discord is your thing, we have a bot connecting both services so
+            We mainly talk on IRC and TeamSpeak. If discord is your thing, we have a bot connecting both services so
             you won't be excluded. Just join the <span>#lounge</span> channel.
           </p>
 
@@ -102,7 +102,7 @@
             <a href="https://irc.hivecom.net" target="_blank"
               ><img src="./public/icons/message-lines-solid.svg" alt=" " />IRC</a
             >
-            <a href="https://discord.gg/Uh4WJ6vV" target="_blank"
+            <a href="https://discord.com/invite/WRrvuhHuCy" target="_blank"
               ><img src="./public/icons/discord-brands.svg" alt=" " />Discord</a
             >
             <a href="https://steamcommunity.com/groups/hivecomnetwork" target="_blank"

--- a/index.html
+++ b/index.html
@@ -125,9 +125,9 @@
           <p>
             The community was originally created by the three server administrators: Catlinman, Jokler and Trif. All
             three started hosting a server back in 2013 on a local machine but the growing demand for a better
-            connection and 24/7 uptime made them reconsider this small hosting plan. They later on that year went over
+            connection and 24/7 uptime made them reconsider this small hosting plan. They later that year went over
             to actually acquiring a dedicated Teamspeak server from Fragnet but later on switched to what is now a
-            server entirely run and managed for Hivecom in itself. <br /><br />
+            server entirely run and managed by Hivecom itself. <br /><br />
           </p>
 
           <h6>Admins</h6>


### PR DESCRIPTION
Fixed a spelling error (TeamsSpeak to TeamSpeak) and updated the Discord invite link since the previous one expired. This one has no expiration date.